### PR TITLE
Refactor main

### DIFF
--- a/rs/crates/test_utils/src/testrepo.rs
+++ b/rs/crates/test_utils/src/testrepo.rs
@@ -200,11 +200,7 @@ impl TestRepo {
         } else {
             format!("{line}\n")
         };
-        let mut gitignore = self
-            .open_file(".gitignore")
-            .write(true)
-            .append(true)
-            .call();
+        let mut gitignore = self.open_file(".gitignore").write(true).append(true).call();
         gitignore
             .write_all(line.as_bytes())
             .expect("Failed writing to .gitinore");

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -7,8 +7,10 @@ use clap::{
     Parser, Subcommand,
 };
 
+pub mod display;
+
 /// CLI for Artisan Tools.
-#[derive(Parser, Clone, Copy)]
+#[derive(Parser, Debug, Clone, Copy)]
 #[command(name = "artisan-tools")]
 #[command(about = "Artisan Tools CLI", version)]
 #[command(styles=STYLES)]
@@ -18,7 +20,7 @@ pub struct Cli {
 }
 
 /// Top-level commands for the CLI.
-#[derive(Subcommand, Clone, Copy)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub enum Command {
     /// Manage version-related operations
     #[command(subcommand, visible_alias = "ver")]
@@ -32,7 +34,7 @@ pub enum Command {
 }
 
 /// Subcommands under `artisan-tools version`
-#[derive(Subcommand, Clone, Copy)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub enum VersionCommand {
     /// Print current version to stdout
     Get {

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -1,0 +1,51 @@
+use crate::changeset::BumpTarget;
+use clap::{
+    builder::{
+        styling::{AnsiColor, Effects},
+        Styles,
+    },
+    Parser, Subcommand,
+};
+
+/// CLI for Artisan Tools.
+#[derive(Parser, Clone, Copy)]
+#[command(name = "artisan-tools")]
+#[command(about = "Artisan Tools CLI", version)]
+#[command(styles=STYLES)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Top-level commands for the CLI.
+#[derive(Subcommand, Clone, Copy)]
+pub enum Command {
+    /// Manage version-related operations
+    #[command(subcommand, visible_alias = "ver")]
+    Version(VersionCommand),
+
+    /// Generate changeset file with the type of bump target
+    Changeset {
+        #[arg(value_enum, default_value_t = BumpTarget::Patch)]
+        target: BumpTarget,
+    },
+}
+
+/// Subcommands under `artisan-tools version`
+#[derive(Subcommand, Clone, Copy)]
+pub enum VersionCommand {
+    /// Print current version to stdout
+    Get {
+        /// Include git information in version string
+        #[arg(long)]
+        git_info: bool,
+    },
+    /// Update version in `VERSION` file
+    Update,
+}
+
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default());

--- a/rs/src/cli/display.rs
+++ b/rs/src/cli/display.rs
@@ -1,0 +1,20 @@
+use super::*;
+use std::fmt;
+
+impl fmt::Display for Cli {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "at {}", self.command)
+    }
+}
+
+impl fmt::Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Command::Version(version_command) => match version_command {
+                VersionCommand::Get { git_info } => write!(f, "version get git_info={git_info}"),
+                VersionCommand::Update => write!(f, "version update"),
+            },
+            Command::Changeset { target } => write!(f, "changeset {}", target.as_str()),
+        }
+    }
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod changeset;
 pub mod cli;
 pub mod git;
+pub mod run;
 pub mod version;

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod changeset;
+pub mod cli;
 pub mod git;
 pub mod version;

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -1,44 +1,8 @@
-use anyhow::{Context, Result};
-use artisan_tools::{
-    changeset,
-    cli::{Cli, Command, VersionCommand},
-    version::AtVersion,
-};
 use clap::Parser;
-use std::fs;
 
-fn main() -> Result<()> {
-    let cli = Cli::parse();
-
-    match cli.command {
-        Command::Version(subcmd) => match subcmd {
-            VersionCommand::Get { git_info } => {
-                // Print current version to stdout
-                let vers = if git_info {
-                    AtVersion::with_metadata(".")?
-                } else {
-                    AtVersion::new(".")?
-                };
-                println!("{vers}");
-            }
-            VersionCommand::Update => {
-                // Update version in `VERSION` file
-                let version_contents = AtVersion::new(".")?;
-
-                fs::write("VERSION", version_contents.to_string())
-                    .context("Failed to write to the VERSION file")?;
-                println!("VERSION updated to {}", version_contents);
-            }
-        },
-        Command::Changeset { target } => {
-            changeset::create_changeset_template("at-changeset", target)
-                .context("Failed to create changeset template")?;
-            println!(
-                "Created new changeset file with target: {}",
-                target.as_str()
-            );
-        }
-    }
-
-    Ok(())
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let cli = artisan_tools::cli::Cli::parse();
+    log::debug!("{cli}");
+    artisan_tools::run::command(cli.command)
 }

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -1,56 +1,11 @@
 use anyhow::{Context, Result};
-use artisan_tools::{changeset, version::AtVersion};
-use clap::{
-    builder::{
-        styling::{AnsiColor, Effects},
-        Styles,
-    },
-    Parser, Subcommand,
+use artisan_tools::{
+    changeset,
+    cli::{Cli, Command, VersionCommand},
+    version::AtVersion,
 };
+use clap::Parser;
 use std::fs;
-
-const STYLES: Styles = Styles::styled()
-    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
-    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
-    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
-    .placeholder(AnsiColor::Cyan.on_default());
-
-/// Simple CLI for Artisan Tools.
-#[derive(Parser)]
-#[command(name = "artisan-tools")]
-#[command(about = "Artisan Tools CLI", version)]
-#[command(styles=STYLES)]
-struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-/// Top-level commands for the CLI.
-#[derive(Subcommand)]
-enum Command {
-    /// Manage version-related operations
-    #[command(subcommand, visible_alias = "ver")]
-    Version(VersionCommand),
-
-    /// Generate changeset file with the type of bump target
-    Changeset {
-        #[arg(value_enum, default_value_t = changeset::BumpTarget::Patch)]
-        target: changeset::BumpTarget,
-    },
-}
-
-/// Subcommands under `artisan-tools version`
-#[derive(Subcommand)]
-enum VersionCommand {
-    /// Print current version to stdout
-    Get {
-        /// Include git information in version string
-        #[arg(long)]
-        git_info: bool,
-    },
-    /// Update version in `VERSION` file
-    Update,
-}
 
 fn main() -> Result<()> {
     let cli = Cli::parse();

--- a/rs/src/run.rs
+++ b/rs/src/run.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+use crate::{
+    changeset,
+    cli::{Command, VersionCommand},
+    version::AtVersion,
+};
+use anyhow::{Context, Result};
+
+/// Run an Artisan Tools command
+pub fn command(cmd: Command) -> Result<()> {
+    match cmd {
+        Command::Version(subcmd) => match subcmd {
+            VersionCommand::Get { git_info } => {
+                // Print current version to stdout
+                let vers = if git_info {
+                    AtVersion::with_metadata(".")?
+                } else {
+                    AtVersion::new(".")?
+                };
+                println!("{vers}");
+            }
+            VersionCommand::Update => {
+                // Update version in `VERSION` file
+                let version_contents = AtVersion::new(".")?;
+
+                fs::write("VERSION", version_contents.to_string())
+                    .context("Failed to write to the VERSION file")?;
+                println!("VERSION updated to {}", version_contents);
+            }
+        },
+        Command::Changeset { target } => {
+            changeset::create_changeset_template("at-changeset", target)
+                .context("Failed to create changeset template")?;
+            println!(
+                "Created new changeset file with target: {}",
+                target.as_str()
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Builds on top of https://github.com/gregerspoulsen/artisan_tools/pull/50

Makes `main.rs` minimal so it only deals with the minimal setup, then we can easily test the rest.

Also add initializing logging in main and a simple log::debug! that prints the state of the parsed cli args in a concise manner.